### PR TITLE
[docs] add initial Less naming conventions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+- [docs] add initial Less naming conventions
 - [docs] add installation recommendations
 - [dev][docs] format markdown files
 - [dev][docs] Add missing types, docs, and update guidelines

--- a/readme.md
+++ b/readme.md
@@ -13,12 +13,13 @@ Vue.js user interface component library prototype for MediaWiki's Vector skin.
 <!-- code_chunk_output -->
 
 - [Table of contents](#table-of-contents)
-- [Installation](#installation)
+- [Installation and version history](#installation-and-version-history)
 - [Development](#development)
   - [Quick start](#quick-start)
   - [NPM scripts](#npm-scripts)
   - [Conventions](#conventions)
     - [Vue.js](#vuejs)
+    - [Less](#less)
     - [TypeScript](#typescript)
   - [Testing](#testing)
     - [Unit Tests](#unit-tests)
@@ -121,9 +122,11 @@ npm install
 
 #### Vue.js
 
-The [Vue.js Style Guide] is adhered to where possible.
+The [Vue.js Style Guide](https://vuejs.org/v2/style-guide) is adhered to where possible.
 
-[vue.js style guide]: https://vuejs.org/v2/style-guide
+#### Less
+
+[BEM](http://getbem.com) naming conventions are adhered to where possible.
 
 #### TypeScript
 


### PR DESCRIPTION
Add BEM for the initial Less naming conventions. The convention may
change dramatically based on the outcome of T255100 but is at least the
interim convention to use until told otherwise.

The link is HTTP because there is no HTTPS site.

Bug: T255100