### PR TITLE
[dev] ignore bundlesize report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /docs/coverage/
 /docs/ui/
+/docs/minGzipBundleSize.txt
 /node_modules/


### PR DESCRIPTION
The bundlesize report is automatically generated and should not be
versioned. Add it to .gitignore.