### PR TITLE
[dev] Improve Jest configuration

### DIFF
--- a/.jest/jest.config.json
+++ b/.jest/jest.config.json
@@ -9,9 +9,14 @@
   "collectCoverage": true,
   "collectCoverageFrom": [
     "<rootDir>/src/**/*.(ts|vue)",
-    "!<rootDir>/src/**/*.(test|snap|stories).ts",
+    "!<rootDir>/src/**/*.(d|test|snap|stories).ts",
     "!<rootDir>/node_modules/**"
 
   ],
-  "coverageDirectory": "<rootDir>/docs/coverage"
+  "coverageDirectory": "<rootDir>/docs/coverage",
+    "globals": {
+      "vue-jest": {
+        "babelConfig": false
+      }
+  }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+- [dev] Improve Jest configuration
 - [dev] Add bundlesize test configuration
 - [dev][docs] Add Storybook development flow, and update readme
 - [docs] add initial Less naming conventions


### PR DESCRIPTION
- Disable Babel. This was printing a warning when the cache was
  invalidated: `npm -s run test:unit -- --no-cache`:

  [vue-jest]: no .babelrc found, skipping babel compilation

- Don't report coverage for TypeScript definitions. These are not
  executable.