### PR TITLE
[dev] Suppress Vue.js Storybook build type reminder

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,10 @@
+import Vue from 'vue';
+
+// Disable informational message in the browser console log:
+//
+//   You are running Vue in development mode.
+//   Make sure to turn on production mode when deploying for production.
+//   See more tips at https://vuejs.org/guide/deployment.html
+//
+// This setting only applies to documentation.
+Vue.config.productionTip = false;

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+- [dev] Suppress Vue.js Storybook build type reminder
 - [dev] Add bundlesize test configuration
 - [dev][docs] Add Storybook development flow, and update readme
 - [docs] add initial Less naming conventions


### PR DESCRIPTION
Disable the build type notification for Storybook documentation. This
library requires Vue.js as a peer dependency but does not ship it. The
Storybook documentation _does_ bundle Vue.js but it's probably better to
offer the development build even in production.