### PR TITLE
[dev][build][Less] add wikimedia-ui-base

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+- [build][less][dev] add wikimedia-ui-base
 - [dev] Format JSON files
 - [build][dev] Upgrade Fork TS Checker Webpack Plugin
 - [dev] Add ESLint and stylelint configs and scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -14854,9 +14854,9 @@
       }
     },
     "prebuild-install": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.4.tgz",
-      "integrity": "sha512-AkKN+pf4fSEihjapLEEj8n85YIw/tN6BQqkhzbDc0RvEZGdkpJBGMUYx66AAMcPG2KzmPQS7Cm16an4HVBRRMA==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.5.tgz",
+      "integrity": "sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -19765,6 +19765,12 @@
           }
         }
       }
+    },
+    "wikimedia-ui-base": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/wikimedia-ui-base/-/wikimedia-ui-base-0.15.0.tgz",
+      "integrity": "sha512-t2GoyqANK41B9VkEgw1gfksDRZfj2+XXbAPgn/CYWk2CrEqZj1LiNrBTcGJ59DWCtUUwgV4MKCfm6Db+cp1Pow==",
+      "dev": true
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "vue-jest": "3.0.5",
     "vue-loader": "15.9.2",
     "vue-template-compiler": "2.6.11",
-    "webpack": "4.43.0"
+    "webpack": "4.43.0",
+    "wikimedia-ui-base": "0.15.0"
   }
 }

--- a/src/components/button/Button.snap.ts
+++ b/src/components/button/Button.snap.ts
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`wvui-button matches the snapshot 1`] = `<button />`;
+exports[`wvui-button matches the snapshot 1`] = `
+<button
+  class="wvui-button"
+/>
+`;

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -1,5 +1,5 @@
 <template>
-	<button @click="onClick">
+	<button class="wvui-button" @click="onClick">
 		<slot />
 	</button>
 </template>
@@ -16,3 +16,11 @@ export default Vue.extend( {
 	}
 } );
 </script>
+
+<style lang="less">
+@import ( reference ) '~wikimedia-ui-base/wikimedia-ui-base.less';
+
+.wvui-button {
+	background: @wmui-color-accent50;
+}
+</style>


### PR DESCRIPTION
Add the wikimedia-ui-base library. This is a needed dependency for all
or most Less variables as noted in the [OOUI migration guide].

An demo usage is included in wvui-button. This usage will be revised
properly when the real styles are added.

[OOUI migration guide]: https://www.mediawiki.org/wiki/Vue.js/OOUI_migration_guide

Bug: T256038