### PR TITLE
[dev] Add Storybook viewports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 
 /dist/
 
-/docs/coverage/
-/docs/ui/
-/docs/minGzipBundleSize.txt
+/docs/
 
 /.eslintcache
 /.stylelintcache

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import { addParameters } from '@storybook/vue';
 
 // Disable informational message in the browser console log:
 //
@@ -8,3 +9,37 @@ import Vue from 'vue';
 //
 // This setting only applies to documentation.
 Vue.config.productionTip = false;
+
+// See wikimedia-ui-base breakpoints
+const viewports = {
+	mobile: {
+		name: 'Mobile',
+		styles: { width: '320px', height: '320px' }
+	},
+	tablet: {
+		name: 'Tablet',
+		styles: { width: '720px', height: '720px' }
+	},
+	desktop: {
+		name: 'Desktop',
+		styles: { width: '1000px', height: '1000px' }
+	},
+	'desktop-wide': {
+		name: 'Wide desktop',
+		styles: { width: '1200px', height: '1200px' }
+	},
+	'desktop-extra-wide': {
+		name: 'Extra-wide desktop',
+		styles: { width: '2000px', height: '2000px' }
+	}
+};
+
+const backgrounds = {
+	values: [
+		{ name: 'white', value: '#fff' }, // @wmui-color-base100
+		{ name: 'dark', value: '#202122' }, // @wmui-color-base10
+		{ name: 'black', value: '#000' } // @wmui-color-base0
+	]
+};
+
+addParameters( { viewport: { viewports }, backgrounds } );

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+- [dev] Add Storybook viewports
 - [dev] Improve Jest configuration
 - [dev][build] remove deprecated Vue.js types
 - [build][dev] upgrade dependencies

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ npm start
 - `install` / `i`: install project dependencies.
 - `start`: run Storybook [development](#development) flow.
 - `test` / `t`: run different types of tests including unit tests. See [testing](#testing).
-- `run test:unit`: run the unit tests.
+- `run test:unit`: run the unit tests. Pass `-u` to update all Jest snapshots.
 - `run format`: apply lint fixes automatically where available.
 - `version`: increment the version and publish a new release. See [versioning](#versioning).
 
@@ -105,8 +105,7 @@ Undocumented scripts are considered internal utilities and not expressly support
 
 💡 Tips:
 
-- Add `--` to pass arguments to the script. For example, `npm run test:unit -- -u` to update
-  all Jest snapshots.
+- Add `--` to pass arguments to the script command. For example, `npm run test:unit -- -u`.
 - Add `-s` to omit verbose command echoing. For example, `npm -s i` or `npm -s run format`.
 
 <details markdown>
@@ -152,9 +151,10 @@ The [Vue.js Style Guide](https://vuejs.org/v2/style-guide) is adhered to where p
   typed, their contents usually can be inferred.
 - Favor type inference for locals rather than explicit typing. Locals are unlikely to have incorrect
   typing assumptions and the verbosity of typing is usually a hindrance.
-- Use TypeScript typing where available, JSDocs where not.
+- Use TypeScript typing where available, JSDoc typing where not. Avoid typing both as this is
+  verbose and the docs may be incorrect.
 
-### Storybook flow
+### Storybook workflow
 
 As the primary development flow WVUI uses [Storybook](https://storybook.js.org/docs/guides/guide-vue/)
 which allows developing UI components in isolation without worrying about  
@@ -455,7 +455,21 @@ The expectations for submitting a patch are:
 - If you as a reviewer are making requests of the author, attempt to match their level of effort and
   timeliness. Everyone is busy and doing their best but differently abled.
 - Be open-minded. New ideas, especially standard ideas that are only new to you, are not inherently
-  bad. You are responsible in part for creating the culture you want.
+  bad. It's ok to downvote to request improved documentation or clarification but not for an
+  education in industry standard practice. You are responsible in part for creating the culture you
+  want.
+
+### Known issues
+
+- `Vue.extend()` is used for the type inference of components. This is anticipated to be replaced by
+  `defineComponent()` in the Vue _v3_ Composition API.
+- [Storybook is incompatible with Vue Devtools]. Tap "Open canvas in a new tab" as a workaround.
+- "Download the React DevTools…" is printed to the browser console
+  [when running Storybook](https://github.com/storybookjs/storybook/issues/4853).
+- If Storybook encounters an error when booting, it does not launch even after the error is
+  resolved.
+
+[storybook is incompatible with vue devtools]: https://github.com/storybookjs/storybook/issues/1708#issuecomment-630262553
 
 ## Performance
 


### PR DESCRIPTION
- Add viewport breakpoints from wikimedia-ui-base to Storybook. Also add
  black and dark backgrounds.

- Simplify .gitignore's automatic generated documentation. Assume the
  whole directory until otherwise is needed.

- Miscellaneous documentation improvements.