### PR TITLE
[dev] Disable Prettier for everything except JSON and Markdown files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,10 @@
 !/dist/.eslintrc.json
 
 /docs/
+
+# Some tooling assumes that if a Prettier configuration file is present, all
+# files should be prettier. This is not intended. Only Markdown and JSON should
+# be pretty.
+*.js
+*.ts
+*.vue

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+-   [dev] Disable Prettier for everything except JSON and Markdown files
 -   [docs] Update readme
 -   [dev][build] Add basic webpack configuration
 -   [dev] Format JSON and Markdown better

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@wikimedia/wvui",
   "author": "Wikimedia",
-  "description": "Vue.js user interface components for Wikipedia, MediaWiki, and beyond.",
+  "description": "🧩 Wikimedia Vue UI components. Wikimedia Foundation's Vue.js shared user-interface components for Wikipedia, MediaWiki, and beyond.",
   "version": "0.0.0",
   "keywords": [
     "Vue.js",
     "components",
     "Wikipedia",
     "MediaWiki",
-    "Wikimedia"
+    "Wikimedia",
+    "TypeScript"
   ],
   "homepage": "https://github.com/wikimedia/wvui",
   "repository": "github:wikimedia/wvui",
@@ -32,7 +33,7 @@
     "format:etc": "npm -s run linter:etc -- --write",
     "format:js": "npm -s run linter:js -- --fix .",
     "format:styles": "npm -s run linter:styles -- --fix .",
-    "linter:etc": "prettier './**/*.{json,md}'",
+    "linter:etc": "prettier .",
     "linter:js": "eslint --cache --max-warnings 0 --report-unused-disable-directives --ext .js,.json,.ts,.vue",
     "linter:styles": "stylelint --cache --rd --mw 0",
     "preversion": "[ -z \"$(git status -z)\" ]",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 # 🧩 Wikimedia Vue UI
 
-Vue.js user interface component library prototype for MediaWiki's Vector skin.
+Wikimedia Vue UI components. Wikimedia Foundation's Vue.js shared user-interface components for
+Wikipedia, MediaWiki, and beyond.
 
 ## Table of contents
 


### PR DESCRIPTION
T256693 added a Prettier configuration file to Wikimediafy the
formatting. Unfortunately, some tooling assumes that if a Prettier
configuration is present, it applies to all files. Since we currently
only use Prettier for JSON and Markdown, this means it incorrectly runs
on everything else. This patch updates the Prettier ignores to exclude
those files.