### PR TITLE
[dev] Improve ESLint TypeScript config and fix JS config typing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,10 @@
 	"rules": {
 		// Deprecated and interferes with JSDoc typing.
 		"valid-jsdoc": "off",
+		// Covered by TypeScript. Doesn't understand many types like `Required`. These rules should be
+		// mostly disabled by setting `mode` to TypeScript but it doesn't seem to be working.
+		"jsdoc/no-undefined-types": "off",
+		"jsdoc/valid-types": "off",
 		// Covered by TypeScript.
 		"no-undef": "off",
 		// Adequately covered by tsconfig.json which allows unused variables with a leading underscore.
@@ -70,5 +74,10 @@
 			"files": ["*.test.ts"],
 			"extends": ["plugin:jest/recommended"]
 		}
-	]
+	],
+	"settings": {
+		"jsdoc": {
+			"mode": "typescript"
+		}
+	}
 }

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,7 +13,7 @@ module.exports = {
 		'@storybook/addon-links'
 	],
 	/**
-	 * @param {import('webpack').Configuration} config
+	 * @param {Required<import('webpack').Configuration>} config
 	 * @return {import('webpack').Configuration}
 	 */
 	webpackFinal: ( config ) => {

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+-   [dev] Improve ESLint TypeScript config and fix JS config typing
 -   [docs] Update readme
 -   [dev][build] Add basic webpack configuration
 -   [dev] Format JSON and Markdown better

--- a/readme.md
+++ b/readme.md
@@ -477,6 +477,9 @@ The expectations for submitting a patch are:
     [when running Storybook](https://github.com/storybookjs/storybook/issues/4853).
 -   If Storybook encounters an error when booting, it does not launch even after the error is
     resolved.
+-   JavaScript configuration files are not type checked when building the library. This seems to be
+    because Webpack shakes out dead code. All types can be tested manually via
+    `npx tsc --noEmit --incremental false`.
 
 [storybook is incompatible with vue devtools]:
 	https://github.com/storybookjs/storybook/issues/1708#issuecomment-630262553

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,5 +40,10 @@
 		"importsNotUsedAsValues": "preserve"
 	},
 
+	// Add hidden files and folders so configuration typing can be tested.
+	"include": ["./**/*", ".*/**/*"],
+
+	// Ignore generated folders. node_modules is ignored by default when `exclude` is unset but needs
+	// to be specified since `exclude` is overridden.
 	"exclude": ["node_modules", "dist", "docs"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,8 +69,12 @@ function plugins() {
 	];
 }
 
-/** @type {webpack.ConfigurationFactory} */
-const config = ( _env, argv ) => ( {
+/**
+ * @param {Parameters<webpack.ConfigurationFactory>[0]} _env
+ * @param {Parameters<webpack.ConfigurationFactory>[1]} argv
+ * @return {ReturnType<webpack.ConfigurationFactory>}
+ */
+module.exports = ( _env, argv ) => ( {
 	stats: {
 		all: false,
 		// Output a timestamp when a build completes. Useful when watching files.
@@ -147,7 +151,5 @@ const config = ( _env, argv ) => ( {
 		new VueLoaderPlugin()
 	]
 } );
-
-module.exports = config;
 
 module.exports.commonConfig = { resolve, rules, plugins };


### PR DESCRIPTION
eslint-plugin-jsdoc has a TypeScript mode. Enable it. Unfortunately, it
doesn't seem to work properly at the moment so disable a couple rules it
says it's supposed to that are causing errors. A similar approach was
taken recently [in the Popups repo] by one of the linter maintainers.

Also, fix the typing in the Storybook and Webpack configs. These aren't
currently being evaluated by the type checker as Webpack shakes them
out as non-functional. However, they can now be tested manually with
`npx tsc --noEmit --incremental false`. The readme has been revised.

[in the Popups repo]: https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Popups/+/536470c01d5bc1e798d9790f2df5645736b8ddcd%5E%21/#F0