### PR TITLE
[dev] Suppress superfluous Jest style warning

### DIFF
--- a/.jest/jest.config.json
+++ b/.jest/jest.config.json
@@ -24,7 +24,9 @@
 	"errorOnDeprecated": true,
 	"globals": {
 		"vue-jest": {
-			"babelConfig": false
+			"babelConfig": false,
+			"//": "Suppress `[vue-jest]: Less and PostCSS are not currently compiled by vue-jest`.",
+			"hideStyleWarn": true
 		}
 	}
 }

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+-   [dev] Suppress superfluous Jest style warning
 -   [docs] Update readme
 -   [dev][build] Add basic webpack configuration
 -   [dev] Format JSON and Markdown better


### PR DESCRIPTION
Styles are intentionally ignored in the Jest transformers but there is
experimental support available for Sass WVUI doesn't use. This was
printing a warning when the cache was invalidated,
`npm -s run test:unit -- --no-cache`:

  [vue-jest]: Less and PostCSS are not currently compiled by vue-jest

Disable the warning.

https://github.com/vuejs/vue-jest/blob/1a6836a/README.md#css-options