### PR TITLE
[build][dev] Enable development releases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
--   [dev] Add package.json files
+-   [build][dev] Enable development releases
 -   [dev] Split ESLint extends and rules
 -   [docs][dev] Document source maps
 -   [dev] Suppress superfluous Jest style warning

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "linter:js": "eslint --cache --max-warnings 0 --report-unused-disable-directives --ext .js,.json,.ts,.vue",
     "linter:styles": "stylelint --cache --rd --mw 0",
     "preversion": "[ -z \"$(git status -z)\" ]",
-    "postversion": "npm publish",
     "prepublishOnly": "git push origin \"$(git rev-parse --abbrev-ref @)\" \"$(git tag --points-at @)\""
   },
   "peerDependencies": {


### PR DESCRIPTION
Decouple versioning from publishing to allow arguments to be passed to
`npm publish`. This is needed to allow pushing the `@next` NPM tag via
`--tag next`.

I've tried to test out the documented procedures locally in a dummy repo
but it's possible I might need to give it another few iterations once
this is merged.