### PR TITLE
[dev] Add wikimedia-ui theme

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+-   [dev] Add wikimedia-ui theme
 -   [dev] Prevent prettier from checking less files
 -   [build][dev] Enable CSS automatic vendor prefixing
 -   [dev] Add package.json files

--- a/src/themes/wikimedia-ui.less
+++ b/src/themes/wikimedia-ui.less
@@ -1,0 +1,18 @@
+@import (reference) '~wikimedia-ui-base/wikimedia-ui-base.less';
+
+@font-size-browser: 16; // assumed browser default of `16px`
+@font-size-base: 0.875 / 1em; // equals `14px` at browser default of `16px`
+@wvui-unit: em;
+
+@size-base: 32 / @font-size-browser / @font-size-base; // equals `2.5em`≈`32px`
+@min-size-widget-base: @size-base;
+
+@background-color-quiet: @wmui-color-base90;
+@background-color-quiet--hover: @wmui-color-base80;
+
+@padding-horizontal-base: 12px;
+@padding-vertical-base: 6px;
+
+@border-radius-base: 3px;
+
+@line-height-base: unit(18 / @font-size-browser / @font-size-base, @wvui-unit);


### PR DESCRIPTION
All incoming component patches (https://github.com/wikimedia/wvui/pull/46, https://github.com/wikimedia/wvui/pull/47) use the same less theme that imports `wikimedia-ui-base.less` and adds some variables to be used for styling components. I've decided to put it to separate patch so that it can be used widely.