### PR TITLE
[build][fix] Export TypeScript definitions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,8 +7,10 @@
 /.eslintrc.json
 /tsconfig.json
 
-# Lint the compiled outputs to validate ES5 but not the generated source maps.
+# Lint the compiled outputs to validate ES5 but not the generated source maps or TypeScript
+# definitions.
 /dist/*.map.json
+/dist/src/
 
 # Lint hidden files and folders.
 !/.jest/

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -23,7 +23,7 @@ module.exports = {
 		Object.assign( config.resolve.extensions, commonConfig.resolve.extensions );
 		Object.assign( config.resolve.alias, commonConfig.resolve.alias );
 		config.module.rules.push( ...commonConfig.rules( config.mode ) );
-		config.plugins.push( ...commonConfig.plugins() );
+		config.plugins.push( ...commonConfig.plugins( config.mode ) );
 		config.performance = {
 			// Disable Webpack bundle size warnings. These apply to the docs only and are not a
 			// priority to fix.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+-   [build][fix] Export TypeScript definitions
 -   [build][dev] Enable development releases
 -   [dev] Add wikimedia-ui theme
 -   [dev] Prevent prettier from checking less files

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "bugs": "https://phabricator.wikimedia.org/tag/vue.js",
   "license": "GPL-2.0+",
   "main": "dist/wvui.js",
+  "types": "dist/src/entries/wvui.d.ts",
   "directories": {
     "lib": "dist/lib",
     "doc": "docs"

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,8 @@
 # 🧩 Wikimedia Vue UI
 
-Wikimedia Vue UI (WVUI) components – [Wikimedia Foundation's](https://wikimediafoundation.org/) Vue.js shared user-interface components for
-Wikipedia, MediaWiki, and beyond. See **[quick start to contribute](#quick-start)**.
+Wikimedia Vue UI (WVUI) components – [Wikimedia Foundation's](https://wikimediafoundation.org/)
+Vue.js shared user-interface components for Wikipedia, MediaWiki, and beyond. See
+**[quick start to contribute](#quick-start)**.
 
 ## Table of contents
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,9 +30,7 @@
 		"sourceMap": true,
 		"outDir": "dist",
 
-		// Emit type definitions (.d.ts) for consumers to test their integration typing. Broken in
-		// current configuration:
-		// https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/issues/49.
+		// Emit type definitions (.d.ts) for consumers to test their integration typing.
 		"declaration": true,
 
 		// Workaround Fork TS Checker Webpack Plugin issue.


### PR DESCRIPTION
Generate TypeScript definitions when building and add them to the NPM
package. These are needed by library consumers using type checking.

There was a broken lint in the readme on master this patch also fixes.