### PR TITLE
[build][dev] Move docs to development release script

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,5 +1,5 @@
+/bin/
 /dist/
-
 /docs/
 
 *.json

--- a/bin/node-test-version
+++ b/bin/node-test-version
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "v$(< .nvmrc)" != "$(node -v)" ]; then
+	echo "Node.js version mismatch. Expected v$(< .nvmrc), \`node -v\` reports $(node -v)."
+	exit 1
+fi

--- a/bin/release-dev
+++ b/bin/release-dev
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A timestamp is used to avoid conflicts as only one tag or version can ever exist. Additionally,
+# the special NPM tags, `@latest` and `@next`, cannot point to the same version. This value is
+# overridable by specifying it as an environment variable before invoking the script.
+PRE_ID="${PRE_ID:-next.$(TZ=utc date +%F-%H-%M)}"
+
+"$(dirname "$0")/node-test-version"
+
+# Validate the installation. See `npm help ci`.
+npm ci
+
+# Development tags are not wanted on the master branch. Checkout `HEAD` detached.
+git checkout origin/master
+
+# This will create a new version commit on the detached `HEAD` like `v1.2.4-next.2020-07-09-20-40.0`.
+npm version prerelease --preid="$PRE_ID"
+
+# Scoped packages (like `@wikimedia/*`) are private by default. Specify that public is wanted.
+# Point the next tag to this release.
+npm publish --access public --tag next

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+-   [build][dev] Move docs to development release script
 -   [update] Flesh out Button props
 -   [dev] Upgrade dependencies
 -   [build][fix] Export TypeScript definitions

--- a/readme.md
+++ b/readme.md
@@ -454,16 +454,7 @@ In those cases, the correct initial alpha release would be `npm version preminor
 
 #### Rolling development release
 
-To publish the current `master` `HEAD`:
-
-1. Execute `git checkout origin/master`.
-2. Execute `npm version prerelease --preid="next.$(TZ=utc date +%F-%H-%M)"`. This will create a new
-   version commit on the detached `HEAD` like `v1.2.4-next.2020-07-09-20-40.0`.
-3. Execute `npm publish --access public --tag next`. This will push the commit
-
-The above steps create a dated version and tag. A timestamp is used to avoid conflicts as only one
-tag or version can ever exist. Additionally, the special NPM tags, `@latest` and `@next`, cannot
-point to the same version.
+To publish the current `master` `HEAD`, execute `bin/release-dev`.
 
 Development releases can be installed by consumers via `npm install @wikimedia/wvui@next`. These
 releases are useful for integration testing and development as well as for early adopters who don't


### PR DESCRIPTION
I keep having to copy and paste these commands from the readme. I wanted
to put them in an NPM script but then I lose all the documentation.
Although I think we should avoid lengthy shell scripts if at all
possible, I think it's worth it in this case for the docs. I also
considered using JavaScript here but all the commands I want to run are
shell.