### PR TITLE
[build][fix] Publish bundled CSS and types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+-   [build][fix] Publish bundled CSS and types
 -   [update] Flesh out Button props
 -   [dev] Upgrade dependencies
 -   [build][fix] Export TypeScript definitions

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   "license": "GPL-2.0+",
   "main": "dist/wvui.js",
   "types": "dist/src/entries/wvui.d.ts",
+  "files": [
+    "dist",
+    "!dist/.eslintrc.json"
+  ],
   "directories": {
     "lib": "dist/lib",
     "doc": "docs"


### PR DESCRIPTION
The CSS and types were not being published in the NPM package, only the
main JavaScript. Publish all of dist except .eslintrc.json.