### PR TITLE
[build][fix] Don't push tags for development releases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.1 (unreleased)
 
+-   [build][fix] Don't push tags for development releases
 -   [build][fix] Publish bundled CSS and types
 -   [build][dev] Include WVUI version in release
 -   [build][dev] Move docs to development release script

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "linter:js": "eslint --cache --max-warnings 0 --report-unused-disable-directives --ext .js,.json,.ts,.vue",
     "linter:styles": "stylelint --cache --rd --mw 0",
     "preversion": "[ -z \"$(git status -z)\" ]",
-    "prepublishOnly": "git push origin $(git branch --show-current) \"$(git tag --points-at @)\""
+    "prepublishOnly": "! git symbolic-ref -q HEAD || git push --follow-tags origin \"$(git branch --show-current)\""
   },
   "peerDependencies": {
     "vue": "^2.6.11"


### PR DESCRIPTION
Development releases are reproducible by passing the timestamp to the
build script. Ideally, we'd keep publishing these tags so they could be
built directly from the commit. However, this is creating a lot of noise
and is unusual. Limit tag publishing to only alpha / beta / release
candidate and final releases.