### PR TITLE
Remove `border-radius-base` override

### DIFF
--- a/src/themes/wikimedia-ui.less
+++ b/src/themes/wikimedia-ui.less
@@ -15,8 +15,6 @@
 @padding-horizontal-input-text: 8px;
 @padding-input-text: @padding-vertical-base @padding-horizontal-input-text;
 
-@border-radius-base: 3px;
-
 @line-height-base: unit(18 / @font-size-browser / @font-size-base, @wvui-unit);
 
 @border-color-input--hover: @border-color-base--active;


### PR DESCRIPTION
`border-radius-base` is `2px` and part of WikimediaUI Base.