### PR TITLE
[dev] Fix transition lint

### DIFF
--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -74,10 +74,7 @@ export default Vue.extend( {
 		height: @size-base;
 
 		&:not( [ disabled ] ) {
-			transition:
-				border-color @transition-duration-medium,
-				box-shadow @transition-duration-medium
-			;
+			transition: border-color @transition-duration-medium, box-shadow @transition-duration-medium;
 		}
 
 		&[ disabled ] {


### PR DESCRIPTION
This patch fixes a Less `transition` lint. I adjusted the linter config
in the Button styles patch but apparently _never_ tested it. This patch
moves the Input transition to appear on one line just like in Button.