### PR TITLE
[build][fix] Expose version as a named export

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,18 +105,35 @@ dependencies instead of in control of them.
 
 ### Integration
 
-The following example demonstrates an integration with the Vue application instance that has access
-to the entire component library and styles:
+The following example demonstrates an integration with the Vue root App that has access to the
+entire WVUI component library and styles:
+
+```html
+<!-- App.vue -->
+<template>
+	<wvui-button>Hello WVUI</wvui-button>
+</template>
+
+<script lang="ts">
+	import Vue from "vue";
+	import components from "@wikimedia/wvui";
+	import "@wikimedia/wvui/dist/wvui.css";
+
+	export default {
+		name: "App",
+		components, // App can compose any WVUI component.
+	};
+</script>
+```
 
 ```ts
+// index.ts
 import Vue from "vue";
-import components from "@wikimedia/wvui";
-import "@wikimedia/wvui/dist/wvui.css";
 import App from "./App.vue";
 
 new Vue({
-	components, // App can compose any WVUI component.
 	el: "#app",
+	components: { App },
 	render: (createElement) => createElement(App),
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,9 @@ Vue.js shared user-interface components for Wikipedia, MediaWiki, and beyond. Se
 <!-- code_chunk_output -->
 
 - [Table of contents](#table-of-contents)
-- [Installation and version history](#installation-and-version-history)
+- [Usage](#usage)
+  - [Installation and version history](#installation-and-version-history)
+  - [Integration](#integration)
   - [Different builds](#different-builds)
 - [Development](#development)
   - [Quick start](#quick-start)
@@ -60,7 +62,9 @@ Vue.js shared user-interface components for Wikipedia, MediaWiki, and beyond. Se
 <!-- /code_chunk_output -->
 <!-- prettier-ignore-end -->
 
-## Installation and version history
+## Usage
+
+### Installation and version history
 
 Install the library and Vue.js v2:
 
@@ -98,6 +102,24 @@ specifies dependencies with looser versioning instead, that project will be at t
 dependencies instead of in control of them.
 
 </details>
+
+### Integration
+
+The following example demonstrates an integration with the Vue application instance that has access
+to the entire component library and styles:
+
+```ts
+import Vue from "vue";
+import components from "@wikimedia/wvui";
+import "@wikimedia/wvui/dist/wvui.css";
+import App from "./App.vue";
+
+new Vue({
+	components, // App can compose any WVUI component.
+	el: "#app",
+	render: (createElement) => createElement(App),
+});
+```
 
 ### Different builds
 

--- a/src/entries/wvui.ts
+++ b/src/entries/wvui.ts
@@ -5,6 +5,7 @@ import WvuiInput from '@/components/input/Input.vue';
 // passed to the Vue app instance's components directly.
 export const version = VERSION;
 
+// Export all components available in the library.
 export default {
 	WvuiButton,
 	WvuiInput

--- a/src/entries/wvui.ts
+++ b/src/entries/wvui.ts
@@ -1,8 +1,11 @@
 import WvuiButton from '@/components/button/Button.vue';
 import WvuiInput from '@/components/input/Input.vue';
 
+// Export version as a named export so that the default export so that the default export can be
+// passed to the Vue app instance's components directly.
+export const version = VERSION;
+
 export default {
-	version: VERSION,
 	WvuiButton,
 	WvuiInput
 };


### PR DESCRIPTION
Export version as the default prevents passing the entire library to the
components of the Vue instance. Move it to a named export instead.