### PR TITLE
[build][dev] Add production and pre-release scripts

### DIFF
--- a/bin/release-dev
+++ b/bin/release-dev
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# Publish a rolling development release.
+#
+# Environment variables:
+# - PRE_ID: Optional prerelease package version identifier. This isn't normally specified except to
+#           reproduce a previous build.
+#
+# Example (if master is v0.0.0, publish v0.0.1-next.2020-01-02-03-04.0):
+#
+#   bin/release-dev
+
 set -euo pipefail
 
 # A timestamp is used to avoid conflicts as only one tag or version can ever exist. Additionally,
@@ -8,13 +18,15 @@ PRE_ID="${PRE_ID:-next.$(TZ=utc date +%F-%H-%M)}"
 
 "$(dirname "$0")/node-test-version"
 
+# Development tags are not wanted on the master branch. Checkout `HEAD` detached.
+git fetch origin master
+git checkout origin/master
+
 # Validate the installation. See `npm help ci`.
 npm ci
 
-# Development tags are not wanted on the master branch. Checkout `HEAD` detached.
-git checkout origin/master
-
-# This will create a new version commit on the detached `HEAD` like `v1.2.4-next.2020-07-09-20-40.0`.
+# This will create a new version commit on the detached `HEAD` like
+# `v1.2.4-next.2020-07-09-20-40.0`.
 npm version prerelease --preid="$PRE_ID"
 
 # Scoped packages (like `@wikimedia/*`) are private by default. Specify that public is wanted.

--- a/bin/release-pre
+++ b/bin/release-pre
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Publish a pre-release (alpha, beta, or release candidate).
+#
+# Environment variables:
+# - TYPE: Required release type: prerelease, prepatch, preminor, or premajor.
+# - PRE_ID: Required package version identifier: alpha, beta, or rc.
+#
+# Example (if master is v0.0.0, publish v0.0.1-rc.0):
+#
+#   TYPE=prerelease PRE_ID=rc bin/release-pre
+
+set -euo pipefail
+
+"$(dirname "$0")/node-test-version"
+
+# Checkout the latest master branch.
+git checkout master
+git pull
+
+# Validate the installation. See `npm help ci`.
+npm ci
+
+# This will create a new version commit on master like `v1.0.1-alpha.0`.
+npm version "$TYPE" --preid="$PRE_ID"
+
+# Scoped packages (like `@wikimedia/*`) are private by default. Specify that public is wanted.
+npm publish --access public

--- a/bin/release-prod
+++ b/bin/release-prod
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Publish a production release. Please see the readme for additional steps.
+#
+# Environment variables:
+# - TYPE: Required release type: patch, minor, or major.
+#
+# Example (if master is v0.0.1-rc.0, publish v0.0.1):
+#
+#   TYPE=patch bin/release-prod
+
+set -euo pipefail
+
+"$(dirname "$0")/node-test-version"
+
+# Make sure the current branch is up to date. This branch should have a local-only commit to revise
+# the changelog.
+git pull
+
+# Validate the installation. See `npm help ci`.
+npm ci
+
+# This will create a new version commit on the current branch like `v1.0.1`.
+npm version "$TYPE"
+
+# Scoped packages (like `@wikimedia/*`) are private by default. Specify that public is wanted.
+npm publish --access public

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.2 (unreleased)
 
+-   [build][dev] Add production and pre-release scripts
+
 ## v0.0.1
 
 -   [component][input] Add icon implementation for input

--- a/readme.md
+++ b/readme.md
@@ -417,16 +417,19 @@ some measure of fixing or "formatting" problems automatically by executing `npm 
 
 To publish a new release:
 
-1. Update the [changelog](changelog.md) with release notes.
-2. Commit the changelog.
-3. Execute `npm version <patch|minor|major>`.
-4. Execute `npm publish --access public`.
+1. Checkout the latest master branch: `git checkout master && git pull`.
+2. Update the [changelog](changelog.md) with release notes.
+3. Commit the changelog.
+4. Execute `TYPE=<patch|minor|major> bin/release-prod`.
 5. Perform a [rolling development release](#rolling-development-release).
 
 <details markdown>
 <summary>Expand for example…</summary>
 
 ```bash
+# Checkout the latest master branch.
+git checkout master && git pull
+
 # Review the changes since the last release. For example,
 # `git log "$(git describe --tags --abbrev=0)..@" --oneline`.
 
@@ -441,10 +444,7 @@ git add changelog.md
 git commit -m '[docs][changelog] prepare release notes'
 
 # Version, build, and test a release.
-npm version minor
-
-# Publish the release
-npm publish --access public
+TYPE=patch bin/release-prod
 ```
 
 </details>
@@ -498,26 +498,24 @@ See also:
 
 #### Pre-release (alpha, beta, or release candidate)
 
-To publish a new alpha, beta, or release candidate:
-
-1. Execute `npm version <prerelease|prepatch|preminor|premajor> --preid=<alpha|beta|rc>`. This will
-   create a new version commit on the current branch.
-2. Execute `npm publish --access public`.
+To publish a new alpha, beta, or release candidate, execute
+`TYPE=<prerelease|prepatch|preminor|premajor> PRE_ID=<alpha|beta|rc> bin/release-pre`. This will
+create a new version commit on the current branch.
 
 <details markdown>
 <summary>Expand for details on which version to use…</summary>
 
 `prerelease` is the safest choice. It always bumps the metadata number and _only_ bumps the patch
 number if a stable version exists. For example, given the current version is a stable v1.2.3,
-`npm version prerelease --preid=alpha` will create `v1.2.4-alpha.0`. Note that both the patch is
-bumped and metadata is added. If executed _again_, note that only the metadata number is bumped and
-the patch number stays the same: `v1.2.4-alpha.1`.
+`TYPE=prerelease PRE_ID=alpha bin/release-pre` will create `v1.2.4-alpha.0`. Note that both the
+patch is bumped and metadata is added. If executed _again_, note that only the metadata number is
+bumped and the patch number stays the same: `v1.2.4-alpha.1`.
 
 `prerelease` can be slightly incorrect if the next release is known to be a minor or major release.
-In those cases, the correct initial alpha release would be `npm version preminor --preid=alpha` (or
-`premajor`) which would create `v1.3.0-alpha.0`. The subsequent alpha release would then be
-`npm version prerelease --preid=alpha` (note the command changes to `prerelease`) which creates
-`v1.3.0-alpha.1`.
+In those cases, the correct initial alpha release would be
+`TYPE=preminor PRE_ID=alpha bin/release-pre` (or `premajor`) which would create `v1.3.0-alpha.0`.
+The subsequent alpha release would then be `TYPE=prerelease PRE_ID=alpha bin/release-pre` (note the
+command `TYPE` changes to `prerelease`) which creates `v1.3.0-alpha.1`.
 
 </details>
 


### PR DESCRIPTION
Like the rolling development releases, the pre-release and production
releases require executing a number of shell commands that are easily
botched and don't fit into an NPM script. Add new scripts to automate
where possible.