### PR TITLE
[component][typeahead-suggestion] Add highlighting as a directive

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -1,6 +1,6 @@
 {
 	"files": [
-		{ "path": "./dist/wvui.js", "maxSize": "2.5 KB" },
+		{ "path": "./dist/wvui.js", "maxSize": "2.6 KB" },
 		{ "path": "./dist/wvui.css", "maxSize": "1.4 KB" }
 	]
 }

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.2 (unreleased)
 
+-   [component][typeahead-suggestion] Implement title highlighting as a directive
 -   [component][typeahead-suggestion] Add initial styles and props
 -   [build][dev] Add production and pre-release scripts
 

--- a/src/components/typeahead-suggestion/TypeaheadSuggestion.snap.ts
+++ b/src/components/typeahead-suggestion/TypeaheadSuggestion.snap.ts
@@ -1,69 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`matches the snapshot Case 0 With thumbnail: ({"suggestion": [Object]}) => HTML 1`] = `
-<li
-  class="wvui-typeahead-suggestion"
->
-  <a
-    class="wvui-typeahead-suggestion__link"
-    href="/wiki/Obsessive–compulsive_disorder"
-  >
-    <span
-      class="wvui-typeahead-suggestion__thumbnail"
-      style="background-image: url(//upload.wikimedia.org/wikipedia/commons/thumb/1/1b/OCD_handwash.jpg/192px-OCD_handwash.jpg);"
-    />
-     
-    <span
-      class="wvui-typeahead-suggestion__text"
-    >
-      <span
-        class="wvui-typeahead-suggestion__title"
-      >
-        Obsessive–compulsive disorder
-      </span>
-       
-      <span
-        class="wvui-typeahead-suggestion__description"
-      >
-        anxiety disorder that involves unwanted and repeated thoughts, feelings, ideas, sensations (obsessions), or behaviors that make them feel driven to do something (compulsions)
-      </span>
-    </span>
-  </a>
-</li>
-`;
-
-exports[`matches the snapshot Case 1 Without thumbnail: ({"suggestion": [Object]}) => HTML 1`] = `
-<li
-  class="wvui-typeahead-suggestion"
->
-  <a
-    class="wvui-typeahead-suggestion__link"
-    href="/wiki/Ob"
-  >
-    <span
-      class="wvui-typeahead-suggestion__thumbnail-placeholder"
-    />
-     
-    <span
-      class="wvui-typeahead-suggestion__text"
-    >
-      <span
-        class="wvui-typeahead-suggestion__title"
-      >
-        Ob
-      </span>
-       
-      <span
-        class="wvui-typeahead-suggestion__description"
-      >
-        
-      </span>
-    </span>
-  </a>
-</li>
-`;
-
-exports[`should highlight query in the title 1`] = `
+exports[`matches the snapshot Case 0 With thumbnail: ({"query": "ob", "suggestion": [Object]}) => HTML 1`] = `
 <li
   class="wvui-typeahead-suggestion"
 >
@@ -94,6 +31,35 @@ exports[`should highlight query in the title 1`] = `
         class="wvui-typeahead-suggestion__description"
       >
         anxiety disorder that involves unwanted and repeated thoughts, feelings, ideas, sensations (obsessions), or behaviors that make them feel driven to do something (compulsions)
+      </span>
+    </span>
+  </a>
+</li>
+`;
+
+exports[`matches the snapshot Case 1 Without thumbnail: ({"query": "132", "suggestion": [Object]}) => HTML 1`] = `
+<li
+  class="wvui-typeahead-suggestion"
+>
+  <a
+    class="wvui-typeahead-suggestion__link"
+    href="/wiki/Ob"
+  >
+    <span
+      class="wvui-typeahead-suggestion__thumbnail-placeholder"
+    />
+     
+    <span
+      class="wvui-typeahead-suggestion__text"
+    >
+      <span
+        class="wvui-typeahead-suggestion__title"
+      />
+       
+      <span
+        class="wvui-typeahead-suggestion__description"
+      >
+        
       </span>
     </span>
   </a>

--- a/src/components/typeahead-suggestion/TypeaheadSuggestion.stories.ts
+++ b/src/components/typeahead-suggestion/TypeaheadSuggestion.stories.ts
@@ -20,7 +20,10 @@ export const configurable = (): Vue.Component =>
 				default: boolean( 'Thumbnail?', true )
 			},
 			active: { type: Boolean, default: boolean( 'Active?', false ) },
-			query: { type: String, default: text( 'Query (for highlighting)', 'Ob' ) }
+			query: {
+				type: String,
+				default: text( 'Query (to highlight)', 'ob' )
+			}
 		},
 		computed: {
 			suggestion(): TypeaheadSuggestion {
@@ -68,7 +71,8 @@ export const withInput = (): Vue.Component =>
 		components: { WvuiTypeaheadSuggestion, WvuiInput },
 		data() {
 			return {
-				isVisible: false
+				isVisible: false,
+				query: 'ob'
 			};
 		},
 		computed: {
@@ -78,17 +82,22 @@ export const withInput = (): Vue.Component =>
 		},
 		methods: {
 			onInput( event: InputEvent ): void {
-				const { target } = event;
+				const { value } = event.target as HTMLInputElement;
 
-				this.isVisible = !!( target as HTMLInputElement ).value;
+				this.isVisible = !!value;
+				this.query = value;
 			}
 		},
 		template: `
 		<div class="sb-search-wrapper">
-			<wvui-input icon="search" @input="onInput" placeholder="Type something..."/>
+			<wvui-input 
+				icon="search"
+				@input="onInput" 
+				placeholder="Type ob..."
+			/>
 			<ul class="sb-suggestions-list" v-if="suggestionsList.length">
 				<wvui-typeahead-suggestion
-					query="ob"
+					:query="query"
 					v-for="suggestion in suggestionsList"
 					:suggestion="suggestion"
 					:key="suggestion.id"

--- a/src/components/typeahead-suggestion/TypeaheadSuggestion.test.ts
+++ b/src/components/typeahead-suggestion/TypeaheadSuggestion.test.ts
@@ -4,11 +4,15 @@ import { TypeaheadSuggestion } from './TypeaheadSuggestion';
 import * as suggestionsList from './TypeaheadSuggestion.stories.json';
 
 describe( 'matches the snapshot', () => {
-	type Case = [string, Record<string, TypeaheadSuggestion>];
+	type Case = [string, Record<string, TypeaheadSuggestion | string>];
 
 	const cases: Case[] = [
-		[ 'With thumbnail', { suggestion: suggestionsList.pages[ 1 ] as TypeaheadSuggestion } ],
-		[ 'Without thumbnail', { suggestion: suggestionsList.pages[ 0 ] as TypeaheadSuggestion } ]
+		[ 'With thumbnail', {
+			suggestion: suggestionsList.pages[ 1 ] as TypeaheadSuggestion, query: 'ob'
+		} ],
+		[ 'Without thumbnail', {
+			suggestion: suggestionsList.pages[ 0 ] as TypeaheadSuggestion, query: '132'
+		} ]
 	];
 
 	test.each( cases )( 'Case %# %s: (%p) => HTML', ( _, props ) => {
@@ -16,6 +20,25 @@ describe( 'matches the snapshot', () => {
 
 		expect( wrapper.element ).toMatchSnapshot();
 	} );
+} );
+
+it( 'should render title', () => {
+	const suggestion: TypeaheadSuggestion = suggestionsList.pages[ 1 ] as TypeaheadSuggestion;
+
+	const wrapper = mount(
+		WvuiTypeaheadSuggestion,
+		{
+			propsData: {
+				suggestion,
+				query: null
+			}
+		} );
+
+	const titleElement = wrapper
+		.find( '.wvui-typeahead-suggestion__title' )
+		.element as HTMLElement;
+
+	expect( titleElement.innerText ).toEqual( suggestion.title );
 } );
 
 it( 'should highlight query in the title', () => {
@@ -30,6 +53,5 @@ it( 'should highlight query in the title', () => {
 		} );
 	const emElement = wrapper.find( '.wvui-typeahead-suggestion__matching-title' );
 
-	expect( wrapper.element ).toMatchSnapshot();
 	expect( emElement ).toBeTruthy();
 } );

--- a/src/components/typeahead-suggestion/TypeaheadSuggestion.vue
+++ b/src/components/typeahead-suggestion/TypeaheadSuggestion.vue
@@ -17,7 +17,10 @@
 			/>
 			<span class="wvui-typeahead-suggestion__text">
 				<!--eslint-disable-next-line vue/no-v-html-->
-				<span class="wvui-typeahead-suggestion__title" v-html="suggestionTitle" />
+				<span
+					v-highlighted-text="{query: query, title: suggestion.title}"
+					class="wvui-typeahead-suggestion__title"
+				/>
 				<span
 					class="wvui-typeahead-suggestion__description"
 				>{{ suggestion.description }}</span>
@@ -29,10 +32,13 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { TypeaheadSuggestion } from './TypeaheadSuggestion';
-import WvuiUtils from '../../utils/Utils';
+import { highlightedText } from '../../directives';
 
 export default Vue.extend( {
 	name: 'WvuiTypeaheadSuggestion',
+	directives: {
+		highlightedText
+	},
 	inheritAttrs: false,
 	props: {
 		active: {
@@ -59,31 +65,6 @@ export default Vue.extend( {
 		* */
 		suggestionWikiLink(): string {
 			return `/wiki/${this.suggestion?.key}`;
-		},
-		/*
-		* Formats title adding highlighted query if it matches
-		* */
-		suggestionTitle(): string | undefined {
-			if ( !this.query ) {
-				return this.suggestion?.title;
-			}
-
-			const title = this.suggestion?.title;
-
-			const sanitizedQuery = WvuiUtils.htmlEscape( WvuiUtils.regexpEscape( this.query ) );
-			const matchStartIndex = title.search( new RegExp( sanitizedQuery, 'i' ) );
-
-			if ( matchStartIndex < 0 ) {
-				return WvuiUtils.htmlEscape( title );
-			}
-
-			const matchEndIndex = matchStartIndex + sanitizedQuery.length;
-			const highlightedTitle = title.substring( matchStartIndex, matchEndIndex );
-			const beforeHighlight = title.substring( 0, matchStartIndex );
-			const afterHighlight = title.substring( matchEndIndex, title.length );
-
-			// eslint-disable-next-line max-len
-			return `${beforeHighlight}<em class="wvui-typeahead-suggestion__matching-title">${highlightedTitle}</em>${afterHighlight}`;
 		},
 		/*
 		* Generates a proper value for background-image

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -1,0 +1,36 @@
+import WvuiUtils from '../utils/Utils';
+import { DirectiveFunction, DirectiveOptions } from 'vue';
+
+const highlightedTextDirectiveHandler: DirectiveFunction =
+	( el: HTMLElement, binding ): void => {
+		const { query, title } = binding.value;
+
+		if ( !query ) {
+			el.innerText = title;
+			return;
+		}
+
+		const sanitizedQuery = WvuiUtils.htmlEscape( WvuiUtils.regexpEscape( query ) );
+		const matchStartIndex = title.search( new RegExp( sanitizedQuery, 'i' ) );
+
+		if ( matchStartIndex < 0 ) {
+			el.innerText = title;
+			return;
+		}
+
+		const matchEndIndex = matchStartIndex + sanitizedQuery.length;
+		const highlightedTitle = title.substring( matchStartIndex, matchEndIndex );
+		const beforeHighlight = title.substring( 0, matchStartIndex );
+		const afterHighlight = title.substring( matchEndIndex, title.length );
+
+		// eslint-disable-next-line max-len
+		el.innerHTML = `${beforeHighlight}<em class="wvui-typeahead-suggestion__matching-title">${highlightedTitle}</em>${afterHighlight}`;
+	};
+
+/*
+* Highlights text if there are matches with a query
+* */
+export const highlightedText: DirectiveOptions = {
+	inserted: highlightedTextDirectiveHandler,
+	update: highlightedTextDirectiveHandler
+};

--- a/src/utils/Utils.test.ts
+++ b/src/utils/Utils.test.ts
@@ -9,9 +9,12 @@ it( 'should escape regexp', () => {
 } );
 
 it( 'should escape html', () => {
-	const htmlString = '<>\'"& a';
-	const escapedHtml = '&lt;&gt;&#039;&quot;&amp; a';
+	const htmlString = '<>\'"&';
+	const string = 's';
+	const escapedHtml = '&lt;&gt;&#039;&quot;&amp;';
 	const result = WvuiUtils.htmlEscape( htmlString );
+	const resultUnescaped = WvuiUtils.htmlEscape( string );
 
 	expect( result ).toEqual( escapedHtml );
+	expect( resultUnescaped ).toEqual( string );
 } );


### PR DESCRIPTION
I've decided to refactor highlighting functionality for a suggestion title (see [this patch](https://github.com/wikimedia/wvui/pull/68) ) and ended up with a directive. 