### PR TITLE
Add npm script to clear Jest cache

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.2 (unreleased)
 
+-   [dev] Add npm script to clear Jest cache
 -   [build][dev] Add production and pre-release scripts
 
 ## v0.0.1

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## v0.0.2 (unreleased)
 
--   [dev] Add npm script to clear Jest cache
+-   [docs][dev] Document way to clear Jest cache
 -   [build][dev] Add production and pre-release scripts
 
 ## v0.0.1

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "build": "webpack -p",
     "test": "npm -s run test:unit && npm -s run test:lint && npm -s run build && npm -s run test:size && npm -s run docs",
     "test:unit": "jest -c .jest/jest.config.json",
-    "test:clear": "jest -c .jest/jest.config.json --clearCache",
     "test:lint": "npm -s run test:lint:etc && npm run -s test:lint:styles && npm run -s test:lint:js",
     "test:lint:styles": "npm -s run linter:styles -- .",
     "test:lint:js": "npm -s run linter:js -- .",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "webpack -p",
     "test": "npm -s run test:unit && npm -s run test:lint && npm -s run build && npm -s run test:size && npm -s run docs",
     "test:unit": "jest -c .jest/jest.config.json",
+    "test:clear": "jest -c .jest/jest.config.json --clearCache",
     "test:lint": "npm -s run test:lint:etc && npm run -s test:lint:styles && npm run -s test:lint:js",
     "test:lint:styles": "npm -s run linter:styles -- .",
     "test:lint:js": "npm -s run linter:js -- .",

--- a/readme.md
+++ b/readme.md
@@ -682,7 +682,9 @@ The expectations for submitting a patch are:
 -   JavaScript configuration files are not type checked when building the library. This seems to be
     because Webpack shakes out dead code. All types can be tested manually via
     `npx --no-install tsc --noEmit --incremental false`.
--   The linter doesn't enforce tabs in in TypeScript enumerations or module declarations.
+-   The linter doesn't enforce tabs in TypeScript enumerations or module declarations.
+-   Renaming test files may cause Jest to still try to open the old file name. In that case consider
+    clearing the cache via `npm -s run test:unit -- --clearCache`.
 
 [storybook is incompatible with vue devtools]:
 	https://github.com/storybookjs/storybook/issues/1708#issuecomment-630262553


### PR DESCRIPTION
Renaming test files caused Jest to get confused.
Running this new scripts clears the Jest cache, which resolves this confusion.

[1] https://remarkablemark.org/blog/2018/11/21/jest-clear-cache/
[2] https://github.com/facebook/jest/issues/3705