### PR TITLE
[styles][button] Use WikimediaUI Base `min-width` and `min-height`

### DIFF
--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -50,8 +50,8 @@ export default Vue.extend( {
 .wvui-button {
 	box-sizing: border-box;
 	// Interactive elements have a minimum touch area.
-	min-width: @min-size-widget-base;
-	min-height: @min-size-widget-base;
+	min-width: @min-size-base;
+	min-height: @min-size-base;
 	max-width: @max-width-button;
 	border-radius: @border-radius-base;
 	padding-left: @padding-horizontal-base;

--- a/src/themes/wikimedia-ui.less
+++ b/src/themes/wikimedia-ui.less
@@ -5,7 +5,6 @@
 @wvui-unit: em;
 
 @size-base: 32 / @font-size-browser / @font-size-base; // equals `2.5em`≈`32px`
-@min-size-widget-base: @size-base;
 
 @background-color-quiet: @wmui-color-base90;
 @background-color-quiet--hover: @wmui-color-base80;


### PR DESCRIPTION
Using `px` values is recommended and sufficient for
`min-width` and `min-height`.