### PR TITLE
[build][styles] Update WikimediaUI Base to latest and amend `@line-height-component`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21394,8 +21394,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.1",
@@ -21412,7 +21411,6 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -22133,9 +22131,9 @@
       }
     },
     "wikimedia-ui-base": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/wikimedia-ui-base/-/wikimedia-ui-base-0.16.0.tgz",
-      "integrity": "sha512-kax6I8BFCimeTG5OM9nxl78k0sgWwD1F45iwimVP/aPgSym3qEeGV5f7zjH0GGTlDnSQA+I9X0rdKoXpATIRGQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/wikimedia-ui-base/-/wikimedia-ui-base-0.17.0.tgz",
+      "integrity": "sha512-Gqyb4bawT+yaiXaeUjeQhNwv+YJe3N6EtMalwqWCALD23FY2C+dFcAEAQ2puW6jt4WW/rRw6uNXS5w3EfvsuYw==",
       "dev": true
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
     "webpack": "4.43.0",
     "webpack-bundle-analyzer": "3.8.0",
     "webpack-cli": "3.3.12",
-    "wikimedia-ui-base": "0.16.0"
+    "wikimedia-ui-base": "0.17.0"
   }
 }

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -175,7 +175,7 @@ export default Vue.extend( {
 
 	&__input {
 		background-color: @background-color-base;
-		box-shadow: @box-shadow-widget;
+		box-shadow: @box-shadow-base;
 		color: @color-base--emphasized;
 		margin: 0;
 		border: @border-width-base @border-style-base @border-color-base;
@@ -183,7 +183,7 @@ export default Vue.extend( {
 		padding: @padding-input-text;
 		font-size: inherit;
 		font-family: inherit;
-		line-height: @line-height-base;
+		line-height: @line-height-component;
 		display: block;
 		width: 100%;
 		box-sizing: border-box;

--- a/src/themes/wikimedia-ui.less
+++ b/src/themes/wikimedia-ui.less
@@ -5,20 +5,13 @@
 @wvui-unit: em;
 
 @size-base: 32 / @font-size-browser / @font-size-base; // equals `2.5em`≈`32px`
+@size-indicator: 12 / @font-size-browser / @font-size-base;
 
 @background-color-quiet: @wmui-color-base90;
 @background-color-quiet--hover: @wmui-color-base80;
 
-@padding-horizontal-base: 12px;
-@padding-vertical-base: 6px;
-@padding-horizontal-input-text: 8px;
-@padding-input-text: @padding-vertical-base @padding-horizontal-input-text;
 @opacity-icon-accessory: 0.67;
 
-@line-height-base: unit(18 / @font-size-browser / @font-size-base, @wvui-unit);
+@line-height-component: unit( 20 / @font-size-browser / @font-size-base, @wvui-unit );
 
 @border-color-input--hover: @border-color-base--active;
-
-@box-shadow-widget: inset 0 0 0 1px transparent;
-
-@size-indicator: 12 / @font-size-browser / @font-size-base;


### PR DESCRIPTION
Updating to v0.17.0, removing all variables that are now part of
the Base variables. Also amending `@line-height-component` to 20px
equivalent as `@padding-vertical-base` has been changed upstream to
provide undoubted support of high letter box scripts like Burmese.