### PR TITLE
Combine fetch() and json()

### DIFF
--- a/src/components/typeahead-search/http/SearchClient.ts
+++ b/src/components/typeahead-search/http/SearchClient.ts
@@ -1,13 +1,17 @@
+import { GetJson } from '../../../http/fetch';
+
 export interface SearchClient {
 	/**
 	 * @param query search string to search for
 	 * @param domain the base URL for the wiki without protocol. Example: 'sr.wikipedia.org'
 	 * @param limit maximum number of results
+	 * @param fetchJsonImpl a function which returns a promise that resolves to a json
 	 */
 	fetchByTitle(
 		query: string,
 		domain: string,
-		limit?: number
+		limit?: number,
+		fetchJsonImpl?: GetJson
 	): Promise<SearchResponse>;
 }
 

--- a/src/components/typeahead-search/http/SearchClient.ts
+++ b/src/components/typeahead-search/http/SearchClient.ts
@@ -1,17 +1,13 @@
-import { GetJson } from '../../../http/fetch';
-
 export interface SearchClient {
 	/**
 	 * @param query search string to search for
 	 * @param domain the base URL for the wiki without protocol. Example: 'sr.wikipedia.org'
 	 * @param limit maximum number of results
-	 * @param fetchJsonImpl a function which returns a promise that resolves to a json
 	 */
 	fetchByTitle(
 		query: string,
 		domain: string,
-		limit?: number,
-		fetchJsonImpl?: GetJson
+		limit?: number
 	): Promise<SearchResponse>;
 }
 

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -22,12 +22,12 @@ interface RestThumbnail {
 }
 
 function isRestResponse( response: unknown ): response is RestResponse {
-	return ( response as RestResponse ).pages !== undefined;
+	return Array.isArray( ( response as RestResponse ).pages );
 }
 
 function checkResponse( response: unknown ): Promise<RestResponse> {
 	if ( !isRestResponse( response ) ) {
-		return Promise.reject( 'Not a RestResponse' );
+		return Promise.reject( 'Not a valid RestResponse' );
 	}
 
 	return Promise.resolve( response as RestResponse );

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -48,35 +48,26 @@ function adaptApiResponse( query: string, response: Record<string, unknown> ): S
 	};
 }
 
-// https://www.mediawiki.org/wiki/API:REST_API/Reference#Autocomplete_page_title
-function fetchByTitle(
-	query: string,
-	domain: string,
-	limit: number,
-	getJsonImpl: GetJson | undefined
-): Promise<SearchResponse> {
-	query = query.trim();
-	if ( !query ) {
-		return Promise.resolve( adaptApiResponse( query, { pages: [] } ) );
-	}
-	const params = {
-		q: query,
-		limit: limit
-	};
-	const headers = {
-		accept: 'application/json'
-	};
-
-	const url = `//${domain}/w/rest.php/v1/search/title?${buildQueryString( params )}`;
-
-	const getJson = !getJsonImpl ? fetchJson : getJsonImpl;
-	return getJson( url, { headers } ).then( ( json ) => adaptApiResponse( query, json ) );
-}
-
-export function restSearchClient(): SearchClient {
+export function restSearchClient( fetchJsonImpl?: GetJson ): SearchClient {
 	return {
-		fetchByTitle( query, domain, limit = 10, getJsonImpl = undefined ) {
-			return fetchByTitle( query, domain, limit, getJsonImpl );
+		// https://www.mediawiki.org/wiki/API:REST_API/Reference#Autocomplete_page_title
+		fetchByTitle( query, domain, limit = 10 ): Promise<SearchResponse> {
+			query = query.trim();
+			if ( !query ) {
+				return Promise.resolve( adaptApiResponse( query, { pages: [] } ) );
+			}
+			const params = {
+				q: query,
+				limit: limit
+			};
+			const headers = {
+				accept: 'application/json'
+			};
+
+			const url = `//${domain}/w/rest.php/v1/search/title?${buildQueryString( params )}`;
+
+			const getJson = !fetchJsonImpl ? fetchJson : fetchJsonImpl;
+			return getJson( url, { headers } ).then( ( json ) => adaptApiResponse( query, json ) );
 		}
 	};
 }

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -57,9 +57,11 @@ export function restSearchClient( getJson: FetchJson = fetchJson ): SearchClient
 		// https://www.mediawiki.org/wiki/API:REST_API/Reference#Autocomplete_page_title
 		fetchByTitle( query, domain, limit = 10 ): Promise<SearchResponse> {
 			query = query.trim();
+
 			if ( !query ) {
 				return Promise.resolve( adaptApiResponse( query, { pages: [] } ) );
 			}
+
 			const params = {
 				q: query,
 				limit: limit

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -1,4 +1,4 @@
-import { buildQueryString, fetchJson, GetJson } from '../../../http/fetch';
+import { buildQueryString, fetchJson, FetchJson } from '../../../http/fetch';
 import { SearchClient, SearchResponse } from './SearchClient';
 
 // https://www.mediawiki.org/wiki/API:REST_API/Reference#Search_result_object
@@ -40,7 +40,7 @@ function adaptApiResponse( query: string, restResponse: RestResponse ): SearchRe
 	};
 }
 
-export function restSearchClient( getJson: GetJson = fetchJson ): SearchClient {
+export function restSearchClient( getJson: FetchJson = fetchJson ): SearchClient {
 	return {
 		// https://www.mediawiki.org/wiki/API:REST_API/Reference#Autocomplete_page_title
 		fetchByTitle( query, domain, limit = 10 ): Promise<SearchResponse> {

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -21,8 +21,7 @@ interface RestThumbnail {
 	height?: number | null;
 }
 
-function adaptApiResponse( query: string, response: Record<string, unknown> ): SearchResponse {
-	const restResponse: RestResponse = response as unknown as RestResponse;
+function adaptApiResponse( query: string, restResponse: RestResponse ): SearchResponse {
 	return {
 		query,
 		results:
@@ -59,7 +58,8 @@ export function restSearchClient( getJson: GetJson = fetchJson ): SearchClient {
 
 			const url = `//${domain}/w/rest.php/v1/search/title?${buildQueryString( params )}`;
 
-			return getJson( url, { headers } ).then( ( json ) => adaptApiResponse( query, json ) );
+			return getJson( url, { headers } )
+				.then( ( json ) => adaptApiResponse( query, json as RestResponse ) );
 		}
 	};
 }

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -48,7 +48,7 @@ function adaptApiResponse( query: string, response: Record<string, unknown> ): S
 	};
 }
 
-export function restSearchClient( fetchJsonImpl?: GetJson ): SearchClient {
+export function restSearchClient( getJson: GetJson = fetchJson ): SearchClient {
 	return {
 		// https://www.mediawiki.org/wiki/API:REST_API/Reference#Autocomplete_page_title
 		fetchByTitle( query, domain, limit = 10 ): Promise<SearchResponse> {
@@ -66,7 +66,6 @@ export function restSearchClient( fetchJsonImpl?: GetJson ): SearchClient {
 
 			const url = `//${domain}/w/rest.php/v1/search/title?${buildQueryString( params )}`;
 
-			const getJson = !fetchJsonImpl ? fetchJson : fetchJsonImpl;
 			return getJson( url, { headers } ).then( ( json ) => adaptApiResponse( query, json ) );
 		}
 	};

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -64,7 +64,7 @@ export function restSearchClient( getJson: FetchJson = fetchJson ): SearchClient
 
 			const params = {
 				q: query,
-				limit: limit
+				limit
 			};
 			const headers = {
 				accept: 'application/json'

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -21,20 +21,6 @@ interface RestThumbnail {
 	height?: number | null;
 }
 
-function isRestResponse( response: unknown ): response is RestResponse {
-	return response instanceof Object &&
-		'pages' in response &&
-		Array.isArray( ( response as RestResponse ).pages );
-}
-
-function checkResponse( response: unknown ): Promise<RestResponse> {
-	if ( !isRestResponse( response ) ) {
-		return Promise.reject( 'Invalid RestResponse' );
-	}
-
-	return Promise.resolve( response );
-}
-
 function adaptApiResponse( query: string, restResponse: RestResponse ): SearchResponse {
 	return {
 		query,
@@ -75,8 +61,7 @@ export function restSearchClient( getJson: FetchJson = fetchJson ): SearchClient
 			const url = `//${domain}/w/rest.php/v1/search/title?${buildQueryString( params )}`;
 
 			return getJson( url, { headers } )
-				.then( ( json ) => checkResponse( json ) )
-				.then( ( restResponse ) => adaptApiResponse( query, restResponse ) );
+				.then( ( json ) => adaptApiResponse( query, json as RestResponse ) );
 		}
 	};
 }

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -21,6 +21,18 @@ interface RestThumbnail {
 	height?: number | null;
 }
 
+function isRestResponse( response: unknown ): response is RestResponse {
+	return ( response as RestResponse ).pages !== undefined;
+}
+
+function checkResponse( response: unknown ): Promise<RestResponse> {
+	if ( !isRestResponse( response ) ) {
+		return Promise.reject( 'Not a RestResponse' );
+	}
+
+	return Promise.resolve( response as RestResponse );
+}
+
 function adaptApiResponse( query: string, restResponse: RestResponse ): SearchResponse {
 	return {
 		query,
@@ -59,7 +71,8 @@ export function restSearchClient( getJson: FetchJson = fetchJson ): SearchClient
 			const url = `//${domain}/w/rest.php/v1/search/title?${buildQueryString( params )}`;
 
 			return getJson( url, { headers } )
-				.then( ( json ) => adaptApiResponse( query, json as RestResponse ) );
+				.then( ( json ) => checkResponse( json ) )
+				.then( ( restResponse ) => adaptApiResponse( query, restResponse ) );
 		}
 	};
 }

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -40,15 +40,15 @@ function adaptApiResponse( query: string, restResponse: RestResponse ): SearchRe
 		query,
 		results:
 			restResponse.pages
-				.map( ( page ) => ( {
-					id: page.id,
-					key: page.key,
-					title: page.title,
-					description: page.description,
-					thumbnail: page.thumbnail ? {
-						url: page.thumbnail.url,
-						width: page.thumbnail.width ?? undefined,
-						height: page.thumbnail.height ?? undefined
+				.map( ( { id, key, title, description, thumbnail } ) => ( {
+					id,
+					key,
+					title,
+					description,
+					thumbnail: thumbnail ? {
+						url: thumbnail.url,
+						width: thumbnail.width ?? undefined,
+						height: thumbnail.height ?? undefined
 					} : undefined
 				} ) )
 	};

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -22,7 +22,9 @@ interface RestThumbnail {
 }
 
 function isRestResponse( response: unknown ): response is RestResponse {
-	return Array.isArray( ( response as RestResponse ).pages );
+	return response instanceof Object &&
+		'pages' in response &&
+		Array.isArray( ( response as RestResponse ).pages );
 }
 
 function checkResponse( response: unknown ): Promise<RestResponse> {

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -27,10 +27,10 @@ function isRestResponse( response: unknown ): response is RestResponse {
 
 function checkResponse( response: unknown ): Promise<RestResponse> {
 	if ( !isRestResponse( response ) ) {
-		return Promise.reject( 'Not a valid RestResponse' );
+		return Promise.reject( 'Invalid RestResponse' );
 	}
 
-	return Promise.resolve( response as RestResponse );
+	return Promise.resolve( response );
 }
 
 function adaptApiResponse( query: string, restResponse: RestResponse ): SearchResponse {

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -22,13 +22,6 @@ interface RestThumbnail {
 }
 
 function adaptApiResponse( query: string, response: Record<string, unknown> ): SearchResponse {
-	if ( !( 'pages' in response ) ) {
-		return {
-			query,
-			results: []
-		};
-	}
-
 	const restResponse: RestResponse = response as unknown as RestResponse;
 	return {
 		query,

--- a/src/components/typeahead-search/http/restSearchClient.ts
+++ b/src/components/typeahead-search/http/restSearchClient.ts
@@ -1,4 +1,4 @@
-import { buildQueryString, fetchJson } from '../../../http/fetch';
+import { buildQueryString, fetchJson, GetJson } from '../../../http/fetch';
 import { SearchClient, SearchResponse } from './SearchClient';
 
 // https://www.mediawiki.org/wiki/API:REST_API/Reference#Search_result_object
@@ -52,7 +52,8 @@ function adaptApiResponse( query: string, response: Record<string, unknown> ): S
 function fetchByTitle(
 	query: string,
 	domain: string,
-	limit: number
+	limit: number,
+	getJsonImpl: GetJson | undefined
 ): Promise<SearchResponse> {
 	query = query.trim();
 	if ( !query ) {
@@ -67,14 +68,15 @@ function fetchByTitle(
 	};
 
 	const url = `//${domain}/w/rest.php/v1/search/title?${buildQueryString( params )}`;
-	return fetchJson( url, { headers } )
-		.then( ( json ) => adaptApiResponse( query, json ) );
+
+	const getJson = !getJsonImpl ? fetchJson : getJsonImpl;
+	return getJson( url, { headers } ).then( ( json ) => adaptApiResponse( query, json ) );
 }
 
 export function restSearchClient(): SearchClient {
 	return {
-		fetchByTitle( query, domain, limit = 10 ) {
-			return fetchByTitle( query, domain, limit );
+		fetchByTitle( query, domain, limit = 10, getJsonImpl = undefined ) {
+			return fetchByTitle( query, domain, limit, getJsonImpl );
 		}
 	};
 }

--- a/src/http/fetch.notAvailable.test.ts
+++ b/src/http/fetch.notAvailable.test.ts
@@ -1,6 +1,6 @@
-import { fetch } from './fetch';
+import { fetchJson } from './fetch';
 
 test( 'fetch() not available', async () => {
 	expect.assertions( 1 );
-	await expect( fetch( 'anything' ) ).rejects.toStrictEqual( 'window.fetch() not available' );
+	await expect( fetchJson( 'anything' ) ).rejects.toStrictEqual( 'window.fetch() not available' );
 } );

--- a/src/http/fetch.notAvailable.test.ts
+++ b/src/http/fetch.notAvailable.test.ts
@@ -1,6 +1,0 @@
-import { fetchJson } from './fetch';
-
-test( 'fetch() not available', async () => {
-	expect.assertions( 1 );
-	await expect( fetchJson( 'anything' ) ).rejects.toStrictEqual( 'window.fetch() not available' );
-} );

--- a/src/http/fetch.test.ts
+++ b/src/http/fetch.test.ts
@@ -62,11 +62,12 @@ describe( 'fetch() using window.fetch', () => {
 	} );
 
 	test( '404 response', async () => {
-		const json = await fetchJson( '//en.wikipedia.org/doesNotExist' );
-
-		await expect( json ).toStrictEqual( {} );
+		expect.assertions( 1 );
+		await expect( fetchJson( '//en.wikipedia.org/doesNotExist' ) )
+			.rejects.toStrictEqual( 'Network request failed' );
 
 		if ( mockedRequests ) {
+			expect.assertions( 3 );
 			expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 			expect( fetchMock ).toHaveBeenCalledWith(
 				'//en.wikipedia.org/doesNotExist',

--- a/src/http/fetch.test.ts
+++ b/src/http/fetch.test.ts
@@ -64,7 +64,7 @@ describe( 'fetch() using window.fetch', () => {
 	test( '404 response', async () => {
 		expect.assertions( 1 );
 		await expect( fetchJson( '//en.wikipedia.org/doesNotExist' ) )
-			.rejects.toStrictEqual( 'Network request failed' );
+			.rejects.toStrictEqual( 'Network request failed with HTTP code 404.' );
 
 		if ( mockedRequests ) {
 			expect.assertions( 3 );

--- a/src/http/fetch.test.ts
+++ b/src/http/fetch.test.ts
@@ -1,4 +1,4 @@
-import { buildQueryString, fetch } from './fetch';
+import { buildQueryString, fetchJson } from './fetch';
 import * as jestFetchMock from 'jest-fetch-mock';
 
 const mockedRequests = !process.env.TEST_LIVE_REQUESTS;
@@ -37,10 +37,9 @@ describe( 'fetch() using window.fetch', () => {
 	} );
 
 	test( '200 without init param passed', async () => {
-		const response = await fetch( url );
+		const json = await fetchJson( url );
 
-		expect( response.ok ).toBeTruthy();
-		await expect( response.json() ).resolves.toStrictEqual( { pages: [] } );
+		expect( json ).toStrictEqual( { pages: [] } );
 
 		if ( mockedRequests ) {
 			expect( fetchMock ).toHaveBeenCalledTimes( 1 );
@@ -49,10 +48,9 @@ describe( 'fetch() using window.fetch', () => {
 	} );
 
 	test( '200 with init param passed', async () => {
-		const response = await fetch( url, { mode: 'cors' } );
+		const json = await fetchJson( url, { mode: 'cors' } );
 
-		expect( response.ok ).toBeTruthy();
-		await expect( response.json() ).resolves.toStrictEqual( { pages: [] } );
+		await expect( json ).toStrictEqual( { pages: [] } );
 
 		if ( mockedRequests ) {
 			expect( fetchMock ).toHaveBeenCalledTimes( 1 );
@@ -64,10 +62,9 @@ describe( 'fetch() using window.fetch', () => {
 	} );
 
 	test( '404 response', async () => {
-		const response = await fetch( '//en.wikipedia.org/doesNotExist' );
+		const json = await fetchJson( '//en.wikipedia.org/doesNotExist' );
 
-		expect( response.ok ).toBeFalsy();
-		await expect( response.text() ).resolves.toContain( 'Page not found' );
+		await expect( json ).toStrictEqual( {} );
 
 		if ( mockedRequests ) {
 			expect( fetchMock ).toHaveBeenCalledTimes( 1 );

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -14,7 +14,9 @@ export function fetchJson(
 			if ( response.ok ) {
 				return response.json();
 			} else {
-				return Promise.reject( 'Network request failed' );
+				return Promise.reject(
+					`Network request failed with HTTP code ${response.status}.`
+				);
 			}
 		} );
 }

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -1,4 +1,4 @@
-// a function which returns a promise that resolves to a json
+// a function which returns a promise that resolves to a JSON object
 export type GetJson = (
 	resource: string,
 	init?: RequestInit

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -1,9 +1,20 @@
-// A wrapper for native fetch() in browsers.
+// A wrapper which combines native fetch() in browsers and the following json() call.
 // Currently this rejects the returned promise if window.fetch is not available in the browser.
-// The plan is to add a fallback so we can support older browsers in the future.
-export function fetch( resource: string, init?: RequestInit ): Promise<Response> {
+// The plan is to add a way for clients of this library to pass in an implementation, e.g.
+// using jQuery.ajax(), so we can support older browsers in the future.
+export function fetchJson(
+	resource: string,
+	init?: RequestInit
+): Promise<Record<string, unknown>> {
 	if ( 'fetch' in window ) {
-		return window.fetch( resource, init );
+		return window.fetch( resource, init )
+			.then( ( response ) => {
+				if ( response.ok ) {
+					return response.json();
+				} else {
+					return {};
+				}
+			} );
 	} else {
 		return Promise.reject( 'window.fetch() not available' );
 	}

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -14,7 +14,7 @@ export function fetchJson(
 			if ( response.ok ) {
 				return response.json();
 			} else {
-				return {};
+				return Promise.reject( 'Network request failed' );
 			}
 		} );
 }

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -11,13 +11,13 @@ export function fetchJson(
 ): Promise<unknown> {
 	return fetch( resource, init )
 		.then( ( response ) => {
-			if ( response.ok ) {
-				return response.json();
-			} else {
+			if ( !response.ok ) {
 				return Promise.reject(
 					`Network request failed with HTTP code ${response.status}.`
 				);
 			}
+
+			return response.json();
 		} );
 }
 

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -1,3 +1,9 @@
+// a function which returns a promise that resolves to a json
+export type GetJson = (
+	resource: string,
+	init?: RequestInit
+) => Promise<Record<string, unknown>>;
+
 // A wrapper which combines native fetch() in browsers and the following json() call.
 // Currently this rejects the returned promise if window.fetch is not available in the browser.
 // The plan is to add a way for clients of this library to pass in an implementation, e.g.

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -1,5 +1,5 @@
 // A function which returns a promise that resolves to a JSON object
-export type GetJson = (
+export type FetchJson = (
 	resource: string,
 	init?: RequestInit
 ) => Promise<unknown>;

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -2,13 +2,13 @@
 export type GetJson = (
 	resource: string,
 	init?: RequestInit
-) => Promise<Record<string, unknown>>;
+) => Promise<unknown>;
 
 // A wrapper which combines native fetch() in browsers and the following json() call.
 export function fetchJson(
 	resource: string,
 	init?: RequestInit
-): Promise<Record<string, unknown>> {
+): Promise<unknown> {
 	return fetch( resource, init )
 		.then( ( response ) => {
 			if ( response.ok ) {

--- a/src/http/fetch.ts
+++ b/src/http/fetch.ts
@@ -1,29 +1,22 @@
-// a function which returns a promise that resolves to a JSON object
+// A function which returns a promise that resolves to a JSON object
 export type GetJson = (
 	resource: string,
 	init?: RequestInit
 ) => Promise<Record<string, unknown>>;
 
 // A wrapper which combines native fetch() in browsers and the following json() call.
-// Currently this rejects the returned promise if window.fetch is not available in the browser.
-// The plan is to add a way for clients of this library to pass in an implementation, e.g.
-// using jQuery.ajax(), so we can support older browsers in the future.
 export function fetchJson(
 	resource: string,
 	init?: RequestInit
 ): Promise<Record<string, unknown>> {
-	if ( 'fetch' in window ) {
-		return window.fetch( resource, init )
-			.then( ( response ) => {
-				if ( response.ok ) {
-					return response.json();
-				} else {
-					return {};
-				}
-			} );
-	} else {
-		return Promise.reject( 'window.fetch() not available' );
-	}
+	return fetch( resource, init )
+		.then( ( response ) => {
+			if ( response.ok ) {
+				return response.json();
+			} else {
+				return {};
+			}
+		} );
 }
 
 /**


### PR DESCRIPTION
Combine fetch() and json() so it can be easily replaced by another implementation, like jQuery.ajax().
Add optional parameter to the SearchClient so a client can pass in an alternative getJson() implementation.
If none is provided then native fetch is used.