### PR TITLE
[fix][build] package-lock.json version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21394,8 +21394,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.1",
@@ -21412,7 +21411,6 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -22133,9 +22131,9 @@
       }
     },
     "wikimedia-ui-base": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/wikimedia-ui-base/-/wikimedia-ui-base-0.16.0.tgz",
-      "integrity": "sha512-kax6I8BFCimeTG5OM9nxl78k0sgWwD1F45iwimVP/aPgSym3qEeGV5f7zjH0GGTlDnSQA+I9X0rdKoXpATIRGQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/wikimedia-ui-base/-/wikimedia-ui-base-0.17.0.tgz",
+      "integrity": "sha512-Gqyb4bawT+yaiXaeUjeQhNwv+YJe3N6EtMalwqWCALD23FY2C+dFcAEAQ2puW6jt4WW/rRw6uNXS5w3EfvsuYw==",
       "dev": true
     },
     "word-wrap": {


### PR DESCRIPTION
Use NVM's version of Node.js to install dependencies. Validated with
`npm ci`.